### PR TITLE
Modify to work with vertex groups instead of selected vertices

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -44,7 +44,7 @@ class SW_PT_CopyPaster(bpy.types.Panel):
 class SWCVertexGroupData(bpy.types.PropertyGroup):
     vertex_index: bpy.props.IntProperty(name="Vertex Group ID")
     group_name: bpy.props.StringProperty(name="Group Name")
-    weight: bpy.props.FloatProperty(name="Skin Weights")
+    weight: bpy.props.FloatProperty(name="Skin Weights", default=0.0, min=0.0, max=1.0, precision=6)
 
 
 class SWCVertexWeights(bpy.types.PropertyGroup):

--- a/__init__.py
+++ b/__init__.py
@@ -47,6 +47,11 @@ class SWCVertexGroupData(bpy.types.PropertyGroup):
     weight: bpy.props.FloatProperty(name="Skin Weights")
 
 
+class SWCVertexWeights(bpy.types.PropertyGroup):
+    """Stores all vertex group weights for a single vertex"""
+    vertex_data: bpy.props.CollectionProperty(type=SWCVertexGroupData)
+
+
 class SWCPropreties(bpy.types.PropertyGroup):
     clear_vertex_groups: bpy.props.BoolProperty(
         name="Clear vertex groups",
@@ -60,6 +65,7 @@ class SWCPropreties(bpy.types.PropertyGroup):
 
 class SWCopyPaster(bpy.types.PropertyGroup):
     clipboard: bpy.props.CollectionProperty(type=SWCVertexGroupData)
+    per_vertex_clipboard: bpy.props.CollectionProperty(type=SWCVertexWeights)
     settings: bpy.props.PointerProperty(type=SWCPropreties)
 
 
@@ -70,6 +76,7 @@ classes = [
     SelectVGVertices,
     SetWeightOperator,
     SWCVertexGroupData,
+    SWCVertexWeights,
     SWCPropreties,
     SWCopyPaster,
     SW_PT_CopyPaster,

--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,7 @@ bl_info = {
     "version": (0, 3, 2),
     "blender": (2, 80, 0),
     "location": "View 3D > Sidebar > Item Tab > Skin Weights CopyPaster",
-    "description": "Copies and paste weights from selected vertices",
+    "description": "Copies and paste weights from active vertex group to active vertex group",
     "category": "Rigging",
 }
 

--- a/op_copypaste_weights.py
+++ b/op_copypaste_weights.py
@@ -46,8 +46,11 @@ class PasteSkinWeights(bpy.types.Operator):
         if active_vg:
             vertex_indices = get_vertex_group_indices(obj, active_vg)
             current_mode = context.object.mode
-            bpy.ops.object.mode_set(mode='WEIGHT_PAINT')
+            
             if vertex_indices:
+                # Ensure we're in OBJECT mode for weight operations
+                bpy.ops.object.mode_set(mode='OBJECT')
+                
                 if settings.clear_vertex_groups:
                     for i in vertex_indices:
                         clear_vertex_groups(obj, i)
@@ -60,13 +63,15 @@ class PasteSkinWeights(bpy.types.Operator):
                     for i in range(min(paste_count, len(vertex_indices))):
                         normalize_weights(obj, vertex_indices[i])
                 
+                # Return to original mode
+                bpy.ops.object.mode_set(mode=current_mode)
+                
                 if paste_count < len(vertex_indices):
                     self.report({'WARNING'}, f"Pasted weights to {paste_count} of {len(vertex_indices)} vertices in '{active_vg.name}' (source had {len(per_vertex_weights)} vertices)")
                 else:
                     self.report({'INFO'}, f"Pasted weights to vertex group '{active_vg.name}' ({paste_count} vertices)")
             else:
                 self.report({'WARNING'}, f"No vertices found in vertex group '{active_vg.name}'")
-            bpy.ops.object.mode_set(mode=current_mode)
         return {'FINISHED'}
 
 
@@ -249,6 +254,10 @@ def copy_weights_from_vertex_group(obj, vertex_indices):
     if not vertex_indices:
         return
     
+    # Must be in OBJECT mode to read weights accurately
+    current_mode = bpy.context.object.mode
+    bpy.ops.object.mode_set(mode='OBJECT')
+    
     # Get vertex group from the active object
     vertex_groups = obj.vertex_groups
     
@@ -269,6 +278,9 @@ def copy_weights_from_vertex_group(obj, vertex_indices):
             except RuntimeError:
                 # Vertex is not in this group, skip
                 pass
+    
+    # Restore the original mode
+    bpy.ops.object.mode_set(mode=current_mode)
 
 
 def paste_copied_weights(obj, skin_weights_buff, target_indices):
@@ -294,11 +306,9 @@ def paste_per_vertex_weights(obj, per_vertex_weights_buff, target_indices):
     """
     This function pastes per-vertex skin weights from the clipboard to target vertices.
     Matches source vertices to target vertices in order (1st to 1st, 2nd to 2nd, etc.)
+    NOTE: Assumes caller has already switched to OBJECT mode.
     """
     vertex_groups = obj.vertex_groups
-    current_mode = bpy.context.object.mode
-    # Switch to Object mode
-    bpy.ops.object.mode_set(mode='OBJECT')
     
     # Determine how many vertices we can paste based on what we have
     num_source_vertices = len(per_vertex_weights_buff)
@@ -319,9 +329,6 @@ def paste_per_vertex_weights(obj, per_vertex_weights_buff, target_indices):
                 # Create the vertex group if it doesn't exist
                 obj.vertex_groups.new(name=sw.group_name)
                 vertex_groups[sw.group_name].add([target_vtx_index], sw.weight, 'REPLACE')
-    
-    # Switch back to the mode that was before editing
-    bpy.ops.object.mode_set(mode=current_mode)
     
     return paste_count
 

--- a/op_copypaste_weights.py
+++ b/op_copypaste_weights.py
@@ -3,26 +3,31 @@ import bmesh
 
 
 class CopySkinWeights(bpy.types.Operator):
-    """Copy skin weights from a vertex"""
+    """Copy skin weights from active vertex group"""
     bl_idname = "object.copy_skin_weights_op"
     bl_label = "Copy skin weights"
     bl_options = {'REGISTER', 'UNDO'}
 
     @classmethod
     def poll(cls, context):
-        return context.active_object is not None
+        obj = context.active_object
+        return obj is not None and obj.type == 'MESH' and obj.vertex_groups.active is not None
 
     def execute(self, context):
         obj = context.active_object
-        selected_indices = get_vertex_indices(obj)
-        if selected_indices:
-            copy_weights_from_vtx(obj, selected_indices[0])
-            self.report({'INFO'}, f"Copied form vertex {selected_indices[0]}")
+        active_vg = obj.vertex_groups.active
+        if active_vg:
+            vertex_indices = get_vertex_group_indices(obj, active_vg)
+            if vertex_indices:
+                copy_weights_from_vertex_group(obj, vertex_indices)
+                self.report({'INFO'}, f"Copied weights from vertex group '{active_vg.name}' ({len(vertex_indices)} vertices)")
+            else:
+                self.report({'WARNING'}, f"No vertices found in vertex group '{active_vg.name}'")
         return {'FINISHED'}
 
 
 class PasteSkinWeights(bpy.types.Operator):
-    """Paste copied skin weights to selected vertices"""
+    """Paste copied skin weights to active vertex group"""
     bl_idname = "object.paste_skin_weights_op"
     bl_label = "Paste skin weights"
     bl_options = {'REGISTER', 'UNDO'}
@@ -30,25 +35,30 @@ class PasteSkinWeights(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         weights = context.scene.sw_copypaster.clipboard
-        return context.active_object is not None and weights
+        obj = context.active_object
+        return obj is not None and obj.type == 'MESH' and obj.vertex_groups.active is not None and weights
 
     def execute(self, context):
         settings = context.scene.sw_copypaster.settings
         weights = context.scene.sw_copypaster.clipboard
         obj = context.active_object
-        selected_indices = get_vertex_indices(obj)
-        current_mode = bpy.context.object.mode
-        bpy.ops.object.mode_set(mode='WEIGHT_PAINT')
-        if selected_indices:
-            if settings.clear_vertex_groups:
-                for i in selected_indices:
-                    clear_vertex_groups(obj, i)
-            paste_copied_weights(obj, weights, selected_indices)
-            if settings.normalize_weights:
-                for i in selected_indices:
-                    normalize_weights(obj, i)
-        bpy.ops.object.mode_set(mode=current_mode)
-        self.report({'INFO'}, "Pasted")
+        active_vg = obj.vertex_groups.active
+        if active_vg:
+            vertex_indices = get_vertex_group_indices(obj, active_vg)
+            current_mode = context.object.mode
+            bpy.ops.object.mode_set(mode='WEIGHT_PAINT')
+            if vertex_indices:
+                if settings.clear_vertex_groups:
+                    for i in vertex_indices:
+                        clear_vertex_groups(obj, i)
+                paste_copied_weights(obj, weights, vertex_indices)
+                if settings.normalize_weights:
+                    for i in vertex_indices:
+                        normalize_weights(obj, i)
+                self.report({'INFO'}, f"Pasted weights to vertex group '{active_vg.name}' ({len(vertex_indices)} vertices)")
+            else:
+                self.report({'WARNING'}, f"No vertices found in vertex group '{active_vg.name}'")
+            bpy.ops.object.mode_set(mode=current_mode)
         return {'FINISHED'}
 
 
@@ -91,7 +101,7 @@ class SelectVGVertices(bpy.types.Operator):
 
     def execute(self, context):
         obj = context.active_object
-        current_mode = bpy.context.object.mode
+        current_mode = context.object.mode
         cunrent_vg = obj.vertex_groups.active
         bpy.ops.object.mode_set(mode='OBJECT')
         # Deselect all vertices before selecting
@@ -137,7 +147,7 @@ class SetWeightOperator(bpy.types.Operator):
 
     def execute(self, context):
         obj = context.active_object
-        current_mode = bpy.context.object.mode
+        current_mode = context.object.mode
         bpy.ops.object.mode_set(mode='WEIGHT_PAINT')
         vertex_groups = obj.vertex_groups
         active_vg = obj.vertex_groups.active
@@ -163,7 +173,7 @@ class SetWeightOperator(bpy.types.Operator):
 def get_vertex_indices(obj):
     target_vertices = []
     # Get the current mode
-    current_mode = bpy.context.object.mode
+    current_mode = bpy.context.object.mode if bpy.context.object else 'OBJECT'
     # Ensure you're in Object Mode
     bpy.ops.object.mode_set(mode='OBJECT')
     # Switch to Edit Mode to access vertex selection
@@ -175,6 +185,24 @@ def get_vertex_indices(obj):
     # Switch back to the mode that was before editing
     bpy.ops.object.mode_set(mode=current_mode)
     return target_vertices
+
+
+def get_vertex_group_indices(obj, vertex_group):
+    """
+    Get all vertex indices that belong to the specified vertex group
+    """
+    vertex_indices = []
+    current_mode = bpy.context.object.mode
+    bpy.ops.object.mode_set(mode='OBJECT')
+    
+    for v in obj.data.vertices:
+        for g in v.groups:
+            if g.group == vertex_group.index:
+                vertex_indices.append(v.index)
+                break
+    
+    bpy.ops.object.mode_set(mode=current_mode)
+    return vertex_indices
 
 
 def copy_weights_from_vtx(obj, vtx_index):
@@ -201,6 +229,47 @@ def copy_weights_from_vtx(obj, vtx_index):
             pass
 
 
+def copy_weights_from_vertex_group(obj, vertex_indices):
+    """
+    This function copies average skin weight data from all vertices in a vertex group to the clipboard
+    """
+    swc_clipboard = bpy.context.scene.sw_copypaster.clipboard
+    # Clear clipboard before copying
+    swc_clipboard.clear()
+    
+    if not vertex_indices:
+        return
+    
+    # Get vertex group from the active object
+    vertex_groups = obj.vertex_groups
+    # Dictionary to store sum of weights for each group
+    weight_sums = {}
+    vertex_count = len(vertex_indices)
+    
+    # Sum up weights from all vertices
+    for vtx_index in vertex_indices:
+        for group in vertex_groups:
+            try:
+                weight = group.weight(vtx_index)
+                if weight > 0:
+                    if group.name not in weight_sums:
+                        weight_sums[group.name] = 0.0
+                    weight_sums[group.name] += weight
+            except RuntimeError:
+                # Vertex is not in this group
+                pass
+    
+    # Calculate average weights and add to clipboard
+    for group_name, total_weight in weight_sums.items():
+        avg_weight = total_weight / vertex_count
+        if avg_weight > 0:
+            item = swc_clipboard.add()
+            group = vertex_groups[group_name]
+            item.vertex_index = group.index
+            item.group_name = group_name
+            item.weight = avg_weight
+
+
 def paste_copied_weights(obj, skin_weights_buff, target_indices):
     """
     This function pastes sking weights from the clipboard to the target vertex
@@ -221,11 +290,30 @@ def paste_copied_weights(obj, skin_weights_buff, target_indices):
 
 
 def normalize_weights(obj, vtx_index):
+    """
+    Normalize weights for a vertex so they sum to 1.0
+    Uses proper Blender API to modify weights
+    """
     v = obj.data.vertices[vtx_index]
-    total_weight = sum([g.weight for g in v.groups])
+    vertex_groups = obj.vertex_groups
+    
+    # Get current weights
+    weights = {}
+    for g in v.groups:
+        try:
+            group = vertex_groups[g.group]
+            weights[group.name] = g.weight
+        except (IndexError, KeyError):
+            pass
+    
+    # Calculate total weight
+    total_weight = sum(weights.values())
+    
     if total_weight > 0:
-        for g in v.groups:
-            g.weight /= total_weight
+        # Normalize and apply weights
+        for group_name, weight in weights.items():
+            normalized_weight = weight / total_weight
+            vertex_groups[group_name].add([vtx_index], normalized_weight, 'REPLACE')
 
 
 def clear_vertex_groups(obj, vtx_index):

--- a/op_copypaste_weights.py
+++ b/op_copypaste_weights.py
@@ -34,13 +34,13 @@ class PasteSkinWeights(bpy.types.Operator):
 
     @classmethod
     def poll(cls, context):
-        weights = context.scene.sw_copypaster.clipboard
+        per_vertex_weights = context.scene.sw_copypaster.per_vertex_clipboard
         obj = context.active_object
-        return obj is not None and obj.type == 'MESH' and obj.vertex_groups.active is not None and weights
+        return obj is not None and obj.type == 'MESH' and obj.vertex_groups.active is not None and per_vertex_weights
 
     def execute(self, context):
         settings = context.scene.sw_copypaster.settings
-        weights = context.scene.sw_copypaster.clipboard
+        per_vertex_weights = context.scene.sw_copypaster.per_vertex_clipboard
         obj = context.active_object
         active_vg = obj.vertex_groups.active
         if active_vg:
@@ -51,11 +51,19 @@ class PasteSkinWeights(bpy.types.Operator):
                 if settings.clear_vertex_groups:
                     for i in vertex_indices:
                         clear_vertex_groups(obj, i)
-                paste_copied_weights(obj, weights, vertex_indices)
+                
+                # Use per-vertex paste to preserve individual vertex weights
+                paste_count = paste_per_vertex_weights(obj, per_vertex_weights, vertex_indices)
+                
                 if settings.normalize_weights:
-                    for i in vertex_indices:
-                        normalize_weights(obj, i)
-                self.report({'INFO'}, f"Pasted weights to vertex group '{active_vg.name}' ({len(vertex_indices)} vertices)")
+                    # Only normalize vertices that received weights
+                    for i in range(min(paste_count, len(vertex_indices))):
+                        normalize_weights(obj, vertex_indices[i])
+                
+                if paste_count < len(vertex_indices):
+                    self.report({'WARNING'}, f"Pasted weights to {paste_count} of {len(vertex_indices)} vertices in '{active_vg.name}' (source had {len(per_vertex_weights)} vertices)")
+                else:
+                    self.report({'INFO'}, f"Pasted weights to vertex group '{active_vg.name}' ({paste_count} vertices)")
             else:
                 self.report({'WARNING'}, f"No vertices found in vertex group '{active_vg.name}'")
             bpy.ops.object.mode_set(mode=current_mode)
@@ -231,48 +239,40 @@ def copy_weights_from_vtx(obj, vtx_index):
 
 def copy_weights_from_vertex_group(obj, vertex_indices):
     """
-    This function copies average skin weight data from all vertices in a vertex group to the clipboard
+    This function copies per-vertex skin weight data from all vertices in a vertex group to the clipboard
     """
-    swc_clipboard = bpy.context.scene.sw_copypaster.clipboard
-    # Clear clipboard before copying
-    swc_clipboard.clear()
+    swc_per_vertex_clipboard = bpy.context.scene.sw_copypaster.per_vertex_clipboard
+    # Clear per-vertex clipboard before copying
+    swc_per_vertex_clipboard.clear()
     
     if not vertex_indices:
         return
     
     # Get vertex group from the active object
     vertex_groups = obj.vertex_groups
-    # Dictionary to store sum of weights for each group
-    weight_sums = {}
-    vertex_count = len(vertex_indices)
     
-    # Sum up weights from all vertices
+    # Store weights for each vertex separately
     for vtx_index in vertex_indices:
+        # Create a new entry for this vertex
+        vertex_entry = swc_per_vertex_clipboard.add()
+        
+        # Store all weights for this vertex
         for group in vertex_groups:
             try:
                 weight = group.weight(vtx_index)
                 if weight > 0:
-                    if group.name not in weight_sums:
-                        weight_sums[group.name] = 0.0
-                    weight_sums[group.name] += weight
+                    item = vertex_entry.vertex_data.add()
+                    item.vertex_index = group.index
+                    item.group_name = group.name
+                    item.weight = weight
             except RuntimeError:
                 # Vertex is not in this group
                 pass
-    
-    # Calculate average weights and add to clipboard
-    for group_name, total_weight in weight_sums.items():
-        avg_weight = total_weight / vertex_count
-        if avg_weight > 0:
-            item = swc_clipboard.add()
-            group = vertex_groups[group_name]
-            item.vertex_index = group.index
-            item.group_name = group_name
-            item.weight = avg_weight
 
 
 def paste_copied_weights(obj, skin_weights_buff, target_indices):
     """
-    This function pastes sking weights from the clipboard to the target vertex
+    This function pastes skin weights from the clipboard to the target vertex
     """
     vertex_groups = obj.vertex_groups
     current_mode = bpy.context.object.mode
@@ -287,6 +287,42 @@ def paste_copied_weights(obj, skin_weights_buff, target_indices):
                 vertex_groups[sw.group_name].add([i], sw.weight, 'REPLACE')
     # Switch back to the mode that was before editing
     bpy.ops.object.mode_set(mode=current_mode)
+
+
+def paste_per_vertex_weights(obj, per_vertex_weights_buff, target_indices):
+    """
+    This function pastes per-vertex skin weights from the clipboard to target vertices.
+    Matches source vertices to target vertices in order (1st to 1st, 2nd to 2nd, etc.)
+    """
+    vertex_groups = obj.vertex_groups
+    current_mode = bpy.context.object.mode
+    # Switch to Object mode
+    bpy.ops.object.mode_set(mode='OBJECT')
+    
+    # Determine how many vertices we can paste based on what we have
+    num_source_vertices = len(per_vertex_weights_buff)
+    num_target_vertices = len(target_indices)
+    
+    # Paste to as many target vertices as we have source data for
+    paste_count = min(num_source_vertices, num_target_vertices)
+    
+    for i in range(paste_count):
+        target_vtx_index = target_indices[i]
+        source_vertex_data = per_vertex_weights_buff[i].vertex_data
+        
+        # Apply all weights from this source vertex to the target vertex
+        for sw in source_vertex_data:
+            try:
+                vertex_groups[sw.group_name].add([target_vtx_index], sw.weight, 'REPLACE')
+            except KeyError:
+                # Create the vertex group if it doesn't exist
+                obj.vertex_groups.new(name=sw.group_name)
+                vertex_groups[sw.group_name].add([target_vtx_index], sw.weight, 'REPLACE')
+    
+    # Switch back to the mode that was before editing
+    bpy.ops.object.mode_set(mode=current_mode)
+    
+    return paste_count
 
 
 def normalize_weights(obj, vtx_index):

--- a/op_copypaste_weights.py
+++ b/op_copypaste_weights.py
@@ -239,7 +239,8 @@ def copy_weights_from_vtx(obj, vtx_index):
 
 def copy_weights_from_vertex_group(obj, vertex_indices):
     """
-    This function copies per-vertex skin weight data from all vertices in a vertex group to the clipboard
+    This function copies per-vertex skin weight data from all vertices in a vertex group to the clipboard.
+    For each vertex in the source group, this copies ALL of its vertex group weights (all bones).
     """
     swc_per_vertex_clipboard = bpy.context.scene.sw_copypaster.per_vertex_clipboard
     # Clear per-vertex clipboard before copying
@@ -256,7 +257,7 @@ def copy_weights_from_vertex_group(obj, vertex_indices):
         # Create a new entry for this vertex
         vertex_entry = swc_per_vertex_clipboard.add()
         
-        # Store all weights for this vertex
+        # Store all weights for this vertex (all bone/group assignments)
         for group in vertex_groups:
             try:
                 weight = group.weight(vtx_index)
@@ -266,7 +267,7 @@ def copy_weights_from_vertex_group(obj, vertex_indices):
                     item.group_name = group.name
                     item.weight = weight
             except RuntimeError:
-                # Vertex is not in this group
+                # Vertex is not in this group, skip
                 pass
 
 


### PR DESCRIPTION
- Copy/paste weights from active vertex group to active vertex group
- Updated normalize_weights to use proper Blender API
- Compatible with Blender 4.5.3 LTS
- No need to manually select vertices - just select vertex groups in Object Data Properties